### PR TITLE
Fix buildkite agent download command

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -22,9 +22,9 @@ if [[ -n "${BUILDKITE_PLUGIN_OCTOPUS_RELEASE_RELEASENOTESARTIFACTNAME:-}" ]] ; t
     buildkite-agent artifact \
         download \
         "$BUILDKITE_PLUGIN_OCTOPUS_RELEASE_RELEASENOTESARTIFACTNAME" \
-        "releaseNotes.md"
+        "."
     
-    octo_command+=("--releaseNotesFile=releaseNotes.md")
+    octo_command+=("--releaseNotesFile=BUILDKITE_PLUGIN_OCTOPUS_RELEASE_RELEASENOTESARTIFACTNAME")
 fi
 
 function run_octorelease() {


### PR DESCRIPTION
The third command to `buildkite-agent artifact` is actually a directory name to download the artifact into