### PR TITLE
Support multiple file patterns in `packageInclude`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,7 @@ steps:
 
           # (optional) Specifying these will additionally pack and push a package to the Octopus Package Repo
           packageId: "MyPackage" # the ID of the package to push
-          packageInclude: "package*" # File pattern of files to include in package
+          packageInclude: "package*" # File pattern for files to include in package.
+          # To include multiple patterns, seperate them with a space. e.g.:
+          # packageInclude: "package* yarn*"
 ```

--- a/hooks/command
+++ b/hooks/command
@@ -50,7 +50,9 @@ octo_pack_command=("octo" "pack" "--id=${BUILDKITE_PLUGIN_OCTOPUS_RELEASE_PACKAG
 octo_push_command=("octo" "push" "--package=${BUILDKITE_PLUGIN_OCTOPUS_RELEASE_PACKAGEID:-}.${PLUGIN_PACKAGE_VERSION}.zip")
 octo_build_info_command=("octo" "build-information" "--package-id=${BUILDKITE_PLUGIN_OCTOPUS_RELEASE_PACKAGEID:-}" "--version=$PLUGIN_PACKAGE_VERSION" "--file=buildInformation.json")
 if [[ -n "${BUILDKITE_PLUGIN_OCTOPUS_RELEASE_PACKAGEINCLUDE:-}" ]] ; then
-    octo_pack_command+=("--include=$BUILDKITE_PLUGIN_OCTOPUS_RELEASE_PACKAGEINCLUDE")
+    for pattern in $BUILDKITE_PLUGIN_OCTOPUS_RELEASE_PACKAGEINCLUDE; do
+        octo_pack_command+=("--include=$pattern")
+    done
 fi
 
 function run_octopushpack() {


### PR DESCRIPTION
Now you can specify multiple file patterns in the `packageInclude` parameter separated by spaces. Each pattern will be added as a seperate `--include` flag for the the `octo pack` command.