### PR TITLE
Properly sanitise commit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A basic configuration, assuming you already have the relevant Octopus API Key an
 steps:
   - command: echo 'Deploy preview created'
     plugins:
-      - hu-danielgo/octopus-release#v0.1.3:
+      - hu-danielgo/octopus-release#v0.1.5:
           # (optional) Names of env variables containing the API Key and Octopus Server URL
           # By default set to `OCTOPUS_CLI_API_KEY` and `OCTOPUS_CLI_SERVER`.
           octopus-api-key-env: OCTOPUS_CLI_API_KEY

--- a/hooks/command
+++ b/hooks/command
@@ -14,7 +14,7 @@ cat << EOF > ./buildInformation.json
   "Commits":[
       {
          "Id":"$BUILDKITE_COMMIT",
-         "Comment":"$SANITISED_BUILDKITE_MESSAGE"
+         "Comment":$SANITISED_BUILDKITE_MESSAGE
       }
    ]
 }

--- a/hooks/command
+++ b/hooks/command
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-SANITISED_BUILDKITE_MESSAGE=$(echo "$BUILDKITE_MESSAGE" | tr '\n' ' ' | sed 's/"/\\"/g')
+SANITISED_BUILDKITE_MESSAGE=$(echo "$BUILDKITE_MESSAGE" | jq -aRs .)
 cat << EOF > ./buildInformation.json
 {
   "BuildEnvironment":"Buildkite",


### PR DESCRIPTION
Uses `jq` (which is [preinstalled on all elastic-ci agents](https://github.com/buildkite/elastic-ci-stack-for-aws#whats-on-each-machine)) to JSON santise the commit message before putting it in the Build Information.